### PR TITLE
deno.sdk.begut(chore): bump versions of slack tooling to latest releases

### DIFF
--- a/deno.sdk.begut/.slack/apps.json
+++ b/deno.sdk.begut/.slack/apps.json
@@ -2,7 +2,6 @@
   "apps": {
     "T02A074M3U3": {
       "app_id": "A05LUAD7B6V",
-      "IsDev": false,
       "team_domain": "slackbox-ez",
       "team_id": "T02A074M3U3"
     }

--- a/deno.sdk.begut/.slack/config.json
+++ b/deno.sdk.begut/.slack/config.json
@@ -1,3 +1,6 @@
 {
-  "project_id":"561ca564-1cb4-47df-9b7f-9a9533f8736b"
+  "project_id": "561ca564-1cb4-47df-9b7f-9a9533f8736b",
+  "manifest": {
+    "source": "local"
+  }
 }

--- a/deno.sdk.begut/.slack/hooks.json
+++ b/deno.sdk.begut/.slack/hooks.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.3.2/mod.ts"
+  }
+}

--- a/deno.sdk.begut/CHANGELOG.md
+++ b/deno.sdk.begut/CHANGELOG.md
@@ -7,6 +7,7 @@ versioned with [calendar versioning][calver].
 
 ## Changes
 
+- chore(deps): bump versions of slack tooling to latest releases 2025-03-10
 - test: remove the flag that allowed no tests to be tested on test 2024-11-23
 - test: replace "mock-fetch" with "deno-mock-fetch" to avoid error 2024-11-23
 - chore(deps): bump versions of slack tooling to latest releases 2024-11-17

--- a/deno.sdk.begut/flake.lock
+++ b/deno.sdk.begut/flake.lock
@@ -36,17 +36,17 @@
     },
     "nixpkgs-deno": {
       "locked": {
-        "lastModified": 1727294711,
-        "narHash": "sha256-fl3Tq7oJZR1Pxx1n1Nr0v3lPNkjAzGn6zYl9enXnX2I=",
+        "lastModified": 1725980463,
+        "narHash": "sha256-3ruEhwpLlccjwYTvLCyFAtPndcRxAs3XazL2lhOXucI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfb72de3dbe62ff47e59894d50934e03f0602072",
+        "rev": "5ed627539ac84809c78b2dd6d26a5cebeb5ae269",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfb72de3dbe62ff47e59894d50934e03f0602072",
+        "rev": "5ed627539ac84809c78b2dd6d26a5cebeb5ae269",
         "type": "github"
       }
     },

--- a/deno.sdk.begut/flake.nix
+++ b/deno.sdk.begut/flake.nix
@@ -2,11 +2,18 @@
   description = "a kind creation for currencies";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-deno.url = "github:NixOS/nixpkgs/dfb72de3dbe62ff47e59894d50934e03f0602072"; # 1.46.3
+    nixpkgs-deno.url = "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269"; # 1.46.2
     flake-utils.url = "github:numtide/flake-utils";
   };
-  outputs = { nixpkgs, nixpkgs-deno, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      nixpkgs,
+      nixpkgs-deno,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;
@@ -18,15 +25,14 @@
           name = "slackcli";
           src =
             if pkgs.stdenv.isDarwin then
-              pkgs.fetchurl
-                {
-                  url = "https://downloads.slack-edge.com/slack-cli/slack_cli_2.31.0_macOS_64-bit.tar.gz";
-                  sha256 = "15xv5fpm7pdb0jyjniyky4vlafp4g0isnzxf23m7fynw2jkj7s1a";
-                }
+              pkgs.fetchurl {
+                url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.0.0_macOS_64-bit.tar.gz";
+                sha256 = "0xbld1a01354zvh5j8l8cgh4b8lgwrk5ngq04i1vdrfjp981a697";
+              }
             else
               pkgs.fetchurl {
-                url = "https://downloads.slack-edge.com/slack-cli/slack_cli_2.31.0_linux_64-bit.tar.gz";
-                sha256 = "1bdk8c1insqhjkrn3fzc6dzlkgq6y0nvhac6rs3fsv81if8a5fgf";
+                url = "https://downloads.slack-edge.com/slack-cli/slack_cli_3.0.0_linux_64-bit.tar.gz";
+                sha256 = "1lrapyy3lw9gg919nfim6vnnwswmc7kyfr8ywmy3lq5py8gdmgb3";
               };
           unpackPhase = "tar -xzf $src";
           installPhase = ''
@@ -46,5 +52,6 @@
             mkdir -p $SLACK_CONFIG_DIR
           '';
         };
-      });
+      }
+    );
 }

--- a/deno.sdk.begut/import_map.json
+++ b/deno.sdk.begut/import_map.json
@@ -2,7 +2,7 @@
   "imports": {
     "assert/": "https://deno.land/std@0.224.0/assert/",
     "deno-mock-fetch/": "https://deno.land/x/deno_mock_fetch@1.0.1/",
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.14.2/",
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.0/",
     "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/"
   }
 }

--- a/deno.sdk.begut/slack.json
+++ b/deno.sdk.begut/slack.json
@@ -1,5 +1,0 @@
-{
-  "hooks": {
-    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.3.0/mod.ts"
-  }
-}


### PR DESCRIPTION
```
✔ Dependencies (requisites for development)
```