### PR TITLE
js.bolt.surge(build): guard against unexpected get manifest overrides

### DIFF
--- a/js.bolt.surge/CHANGELOG.md
+++ b/js.bolt.surge/CHANGELOG.md
@@ -7,6 +7,7 @@ versioned with [calendar versioning][calver].
 
 ## Changes
 
+- build: guard against important manifest object override 2025-03-15
 - test: track coverage of unit tests for updating insight 2025-03-15
 - test: confirm scripts to get manifests match production 2025-03-15
 - chore: set node versions to a tested production for now 2025-03-15

--- a/js.bolt.surge/scripts/get-manifest.js
+++ b/js.bolt.surge/scripts/get-manifest.js
@@ -13,7 +13,8 @@ if (fs.realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
  */
 function merge(target, source) {
   Object.keys(source).forEach((key) => {
-    if (key in target) {
+    if (key === "__proto__" || key === "constructor") return;
+    if (target.hasOwnProperty(key)) {
       if (typeof target[key] === "object" && typeof source[key] === "object") {
         merge(target[key], source[key]);
       } else {

--- a/js.bolt.surge/test/scripts/get-manifest.spec.js
+++ b/js.bolt.surge/test/scripts/get-manifest.spec.js
@@ -11,6 +11,13 @@ describe("scripts", () => {
       process.env.SLACK_ENVIRONMENT_TAG = undefined;
     });
 
+    it("missing", () => {
+      process.env.SLACK_ENVIRONMENT_TAG = "unknown";
+      assert.throws(() => {
+        getManifest();
+      });
+    });
+
     it("production", () => {
       process.env.SLACK_ENVIRONMENT_TAG = "production";
       const manifest = getManifest();


### PR DESCRIPTION
Potential fix for [https://github.com/zimeg/slack-sandbox/security/code-scanning/5](https://github.com/zimeg/slack-sandbox/security/code-scanning/5)

To fix the problem, we need to modify the `merge` function to prevent prototype pollution. This can be achieved by:
1. Blocking the special properties `__proto__` and `constructor` from being merged.
2. Ensuring that only own properties of the `target` object are merged recursively.

The best way to fix the problem without changing existing functionality is to update the `merge` function to include these checks. Specifically, we will:
- Add a check to skip the properties `__proto__` and `constructor`.
- Add a check to ensure that only own properties of the `target` object are merged recursively.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
